### PR TITLE
Switch to `Module#prepend` in `ActiveRecord::Relation` patch

### DIFF
--- a/lib/standby/active_record/relation.rb
+++ b/lib/standby/active_record/relation.rb
@@ -1,18 +1,17 @@
+module ExecQueriesWithStandbyTarget
+  # Supports queries like User.on_standby.to_a
+  def exec_queries
+    if standby_target
+      Standby.on_standby(standby_target) { super }
+    else
+      super
+    end
+  end
+end
+
 module ActiveRecord
   class Relation
     attr_accessor :standby_target
-
-    # Supports queries like User.on_standby.to_a
-    alias_method :exec_queries_without_standby, :exec_queries
-
-    def exec_queries
-      if standby_target
-        Standby.on_standby(standby_target) { exec_queries_without_standby }
-      else
-        exec_queries_without_standby
-      end
-    end
-
 
     # Supports queries like User.on_standby.count
     alias_method :calculate_without_standby, :calculate
@@ -26,3 +25,5 @@ module ActiveRecord
     end
   end
 end
+
+ActiveRecord::Relation.prepend(ExecQueriesWithStandbyTarget)

--- a/spec/slavery_spec.rb
+++ b/spec/slavery_spec.rb
@@ -104,4 +104,10 @@ describe Standby do
     expect(User.on_standby(:two).where(nil).to_a.size).to be 0
     expect(User.on_standby.where(nil).to_a.size).to be 1
   end
+
+  it 'does not interfere with setting inverses' do
+    user = User.first
+    user.update(name: 'a different name')
+    expect(user.items.first.user.name).to eq('a different name')
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,10 +15,11 @@ ActiveRecord::Base.configurations = {
 # Prepare databases
 class User < ActiveRecord::Base
   has_many :items
+  attr_accessor :name
 end
 
 class Item < ActiveRecord::Base
-  belongs_to :user
+  belongs_to :user, inverse_of: :items
 end
 
 class Seeder

--- a/standby.gemspec
+++ b/standby.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^exe/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
+  gem.required_ruby_version = '>= 2.0'
 
   gem.add_runtime_dependency 'activerecord', '>= 3.0.0'
 


### PR DESCRIPTION
`alias_method` breaks when the parameters for the function we're patching
changes, as it did in rails/rails@caa178c178468f7adcc5f4c597280e6362d9e175

Closes kenn#34.