### PR TITLE
Allow explicit replica reads during transactions.

### DIFF
--- a/lib/standby.rb
+++ b/lib/standby.rb
@@ -17,9 +17,9 @@ module Standby
       @standby_connections ||= {}
     end
 
-    def on_standby(name = :null_state, &block)
+    def on_standby(name = :null_state, allow_replica_read_in_transaction: false, &block)
       raise Standby::Error.new('invalid standby target') unless name.is_a?(Symbol)
-      Base.new(name).run &block
+      Base.new(name, allow_replica_read_in_transaction).run &block
     end
 
     def on_primary(&block)

--- a/lib/standby/base.rb
+++ b/lib/standby/base.rb
@@ -1,7 +1,7 @@
 module Standby
   class Base
-    def initialize(target)
-      @target = decide_with(target)
+    def initialize(target, allow_replica_read_in_transaction = false)
+      @target = decide_with(target, allow_replica_read_in_transaction)
     end
 
     def run(&block)
@@ -10,11 +10,9 @@ module Standby
 
   private
 
-    def decide_with(target)
-      if Standby.disabled || target == :primary
+    def decide_with(target, allow_replica_read_in_transaction)
+      if Standby.disabled || target == :primary || (!allow_replica_read_in_transaction && inside_transaction?)
         :primary
-      elsif inside_transaction?
-        raise Standby::Error.new('on_standby cannot be used inside transaction block!')
       elsif target == :null_state
         :standby
       elsif target.present?

--- a/spec/slavery_spec.rb
+++ b/spec/slavery_spec.rb
@@ -45,9 +45,15 @@ describe Standby do
     end
   end
 
-  it 'raises error in transaction' do
+  it 'redirects to primary in transaction' do
     User.transaction do
-      expect { Standby.on_standby { User.first } }.to raise_error(Standby::Error)
+      expect { Standby.on_standby { expect(standby_value).to be :primary } }
+    end
+  end
+
+  it 'allows standby use in transaction' do
+    User.transaction do
+      expect { Standby.on_standby(allow_replica_read_in_transaction: true) { expect(standby_value).to be :standby } }
     end
   end
 


### PR DESCRIPTION
Will now fallback to the primary instead of raising an exception when replica reads in transactions are not explicitly allowed.