### PR TITLE
Add support for Rails 6 and above configs_for

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ matrix:
   include:
   - rvm: ruby-head
     gemfile: Gemfile
+  - rvm: 2.6
+    gemfile: gemfiles/rails6.1.gemfile
   - rvm: 2.5
     gemfile: gemfiles/rails5.2.gemfile
   - rvm: 2.5

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'activerecord', '~> 6.1'
+
+gemspec name: 'standby', path: '../'

--- a/lib/standby/connection_holder.rb
+++ b/lib/standby/connection_holder.rb
@@ -5,7 +5,13 @@ module Standby
     class << self
       # for delayed activation
       def activate(target)
-        spec = ActiveRecord::Base.configurations["#{ActiveRecord::ConnectionHandling::RAILS_ENV.call}_#{target}"]
+        spec = if ActiveRecord::Base.configurations.respond_to?(:configs_for)
+          env_name = "#{ActiveRecord::ConnectionHandling::RAILS_ENV.call}_#{target}"
+          ActiveRecord::Base.configurations.configs_for(env_name: env_name).first&.configuration_hash
+        else
+          ActiveRecord::Base.configurations["#{ActiveRecord::ConnectionHandling::RAILS_ENV.call}_#{target}"]
+        end
+
         raise Error.new("Standby target '#{target}' is invalid!") if spec.nil?
         establish_connection spec
       end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -20,13 +20,30 @@ describe 'configuration' do
   end
 
   it 'raises error if standby configuration not specified' do
-    ActiveRecord::Base.configurations['test_standby'] = nil
+    if ActiveRecord::Base.configurations.respond_to?(:configs_for)
+      ActiveRecord::Base.configurations = {
+        'test' => { 'adapter' => 'sqlite3', 'database' => 'test_db' },
+        'test_standby_two' => { 'adapter' => 'sqlite3', 'database' => 'test_standby_two' },
+        'test_standby_url' => 'postgres://root:@localhost:5432/test_standby'
+      }
+    else
+      ActiveRecord::Base.configurations['test_standby'] = nil
+    end
 
     expect { Standby.on_standby { User.count } }.to raise_error(Standby::Error)
   end
 
   it 'connects to primary if standby configuration is disabled' do
-    ActiveRecord::Base.configurations['test_standby'] = nil
+    if ActiveRecord::Base.configurations.respond_to?(:configs_for)
+      ActiveRecord::Base.configurations = {
+        'test' => { 'adapter' => 'sqlite3', 'database' => 'test_db' },
+        'test_standby_two' => { 'adapter' => 'sqlite3', 'database' => 'test_standby_two' },
+        'test_standby_url' => 'postgres://root:@localhost:5432/test_standby'
+      }
+    else
+      ActiveRecord::Base.configurations['test_standby'] = nil
+    end
+
     Standby.disabled = true
 
     expect(Standby.on_standby { User.count }).to be 2


### PR DESCRIPTION
Currently, when running against Rails 6 or above the following warning is emitted:

```
DEPRECATION WARNING: [] is deprecated and will be removed from Rails 7.0 (Use configs_for) (called from with_connection at /Users/dougedey/src/gitlab/OpsLevel/app/helpers/database_helper.rb:32)
```

Rails 6.1 switched to using `configs_for` to support multi-database better: https://github.com/rails/rails/pull/33637

Instead of forcing people off Standby, I figured it was easier to support the new and old mechanisms.

And the PagerDuty fork seems to be the most in use repo so I figured it was the best one to patch, let me know if you're not accepting PRs and I'll continue on my own fork.

This is a more complete version of the upstream PR https://github.com/kenn/standby/pull/38